### PR TITLE
Override the GOPATH locally if you have a GOPATH

### DIFF
--- a/static/src/docs/_posts/2017-08-20-installation.md
+++ b/static/src/docs/_posts/2017-08-20-installation.md
@@ -80,7 +80,7 @@ Dependencies:
 
 ```bash
 $ git clone https://github.com/kryptco/kr src/github.com/kryptco/kr 
-$ export GOPATH=$PWD && cd src/github.com/kryptco/kr && make install && kr restart
+$ cd src/github.com/kryptco/kr && GOPATH=$OLDPWD make install && kr restart
 ```
 
 ## How Kr interfaces with SSH


### PR DESCRIPTION
If you have GOPATH already exported, the linux install instructions won't work. If you use the $OLDPATH and set it on the make install, it does work.

Fixes #6 