### PR TITLE
Add support for Catalina

### DIFF
--- a/kr
+++ b/kr
@@ -57,6 +57,7 @@ install_darwin_manual() {
 		10.12) BOTTLE_FILE=kr-2.4.13.sierra.bottle.2.tar.gz;	BOTTLE_HASH=2285ce4eebb3ee75ab9678676c15bf133d5a3d24d2b7a4dc4da31179de699462; USE_KRBTLE=1;;
 		10.13) BOTTLE_FILE=kr-2.4.13.high_sierra.bottle.2.tar.gz; BOTTLE_HASH=b5278156184a7f50ed04790ecc7081be5c3f3d82c07da64d9683bf5db19472cb; USE_KRBTLE=1;;
 		10.14) BOTTLE_FILE=kr-2.4.13.mojave.bottle.2.tar.gz; BOTTLE_HASH=8901218264de65fdbf2dc258f00557e456416f9f32fb9511956d546fea0a804a; USE_KRBTLE=1;;
+		10.15) BOTTLE_FILE=kr-2.4.13.mojave.bottle.2.tar.gz; BOTTLE_HASH=8901218264de65fdbf2dc258f00557e456416f9f32fb9511956d546fea0a804a; USE_KRBTLE=1;;
 		*) say "Unsupported OS X version $MAJOR_MAC_VERSION. Krypton requires 10.11+" && exit 1 ;;
 	esac
 	say Downloading Krypton.


### PR DESCRIPTION
Catalina is supposed to be released tomorrow, and at the moment this script blocks `kr`'s install when the mojave build works fine. So, this is a quick and dirty fix to unblock anyone wanting to install it.

(Yes, you should probably create a new bottle rather than doing this but tbh I'm not too sure how that works and I just needed something to unblock me 😉)

Solves https://github.com/kryptco/kr/issues/280